### PR TITLE
Various improvements.

### DIFF
--- a/QlikResources.psm1
+++ b/QlikResources.psm1
@@ -1871,17 +1871,21 @@ class QlikProxy {
             }
         }
         if($null -ne $this.VirtualProxies) {
-            $vProxList = $item.settings.virtualProxies | foreach { $_.id }
             $set = New-Object System.Collections.Generic.HashSet[string]
-            $this.VirtualProxies | foreach {
-              $eid = Get-QlikVirtualProxy -filter "prefix eq '$_'"
-              If( $eid )
-              {
-                $res = $set.Add($eid.id)
+            $vProxList = $item.settings.virtualProxies | foreach {
+              If ($_.defaultVirtualProxy) {
+                $res = $set.Add($_.id)
               }
+              $_.id
             }
-            Get-QlikVirtualProxy -filter "defaultVirtualProxy eq True" | foreach {
-              $res = $set.Add($_.id)
+            $this.VirtualProxies | foreach {
+              If ($_ -ne '') {
+                $eid = Get-QlikVirtualProxy -filter "prefix eq '$_'"
+                  If( $eid )
+                  {
+                    $res = $set.Add($eid.id)
+                  }
+              }
             }
             if(@($vProxList).Count -ne $set.Count) {
                 Write-Verbose "Test-HasProperties: custom properties count differ - $(@($vProxList).Count) does not match desired state - $($set.Count)"


### PR DESCRIPTION
In resource QlikVirtualProxy:
- loadBalancingServerNodes : logs and Noop if selection empty
- proxyFilter : the proxy list gives an explicit list of hostnames,
proxyFilter lists proxies that matches a filter expression (same design
as loadBalancingServerNodes for proxies)

In resource QlikNode:
The engine/proxy ... params are not mandatory and not nullable. So its default
value is false. Plus, it does not seem possible to unactivate a service that
has been once activated (Bad request, status 400).

I enforced the fact that if they are false, it does no update. If they are
true, it activates the service.